### PR TITLE
fix: add dependency ts-morph for Signals Input migrator

### DIFF
--- a/libs/ngxtension/package.json
+++ b/libs/ngxtension/package.json
@@ -26,6 +26,7 @@
 	"dependencies": {
 		"@nx/devkit": "^17.0.0",
 		"nx": "^17.0.0",
+    "ts-morph": "^21.0.1",
 		"tslib": "^2.3.0"
 	},
 	"sideEffects": false,


### PR DESCRIPTION
Add ts-morph as a dependency, which is needed for the Signals Input migrator.